### PR TITLE
Just sharing a thought

### DIFF
--- a/quest-log/counter.md
+++ b/quest-log/counter.md
@@ -2,26 +2,28 @@
 
 ```typescript
 class Counter {
-  private count: number
+  private count: Mut<number> // defaults to 0
 
   constructor() {
     this.count = 0
   }
   
-  public write increment(): void {
+  public increment(): void {
     this.count++
   }
   
-  public read getValue(): number {
+  // read access is implied
+  public getValue(): number {
     return this.count
   }
 }
 
 function main() {
   let c = new Counter()
-  console.log(read c.getValue()) // "0"
+  // immutable borrow is implied in console.log()
+  console.log(c.getValue()) // "0"
 
   c.increment()
-  console.log(read c.getValue()) // "1"
+  console.log(c.getValue()) // "1"
 }
 ```

--- a/quest-log/simple-http-server.md
+++ b/quest-log/simple-http-server.md
@@ -8,7 +8,7 @@ import { Server, Headers, StatusCode, ContentTypes, Request, Response, HandlerFu
 async function main() {
   const server = new http.Server()
 
-  server.requests.subscribe(function(req: Request, res: Response) {
+  server.requests.subscribe(function(req: Borrow<Request>, res: BorrowMut<Response>) {
     res.setStatus(StatusCode.Ok)
     res.setHeader(Headers.ContentType, ContentTypes.PlainText)
     res.setBody('Hello World!')

--- a/quest-log/simple-wasm-application.md
+++ b/quest-log/simple-wasm-application.md
@@ -12,7 +12,7 @@ import { window, HTMLDivElement } from '@std/dom'
 
 function main() {
   // Mutable reference to a div element
-  let div: HTMLDivElement = window.document.createElement('div')
+  let div: Mut<HTMLDivElement> = window.document.createElement('div')
   div.innerHTML = 'Hello World'
 
   // Move ownership to the body


### PR DESCRIPTION
Utilizing vscode intellisense and the TypeScript language server is very useful, and here, I propose different ways to explicitly denote mutable borrows and move semantics as an *example* of what might be more ergonomic for TypeScript developers using a hypothetical TypeScriptBC compiler.

I don't mind the `read` or `write` directives, as they are clear and understandable, but it might be easier to swim downstream with the typescript language instead of against it.

Any thoughts?